### PR TITLE
Alerts on emergency account sign-ins

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,11 @@
 
 Implement an [Emergency cccess account](https://docs.microsoft.com/en-us/azure/active-directory/roles/security-emergency-access), assign it the Global Administrator-role and Owner-role on the (root) management group.
 
-This account should also be exempt from conditional access policies that enforce MFA, logins should be monitored, and validated regularly
+This account should also be exempt from conditional access policies that enforce MFA, logins should be monitored, and validated regularly.
 
-## Module Overview
+**Note:**
+Set `azure_ad_p2 == true` if your tenant has Azure AD P2-licenses to enable alerts from sign-in logs
 
-<!-- BEGIN_TF_DOC -->
-
-<!-- END_TF_DOC -->
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
@@ -34,6 +32,11 @@ No modules.
 |------|------|
 | [azuread_directory_role_assignment.global_administrator](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/directory_role_assignment) | resource |
 | [azuread_user.breakglass](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/user) | resource |
+| [azurerm_log_analytics_workspace.azure_ad_diagnostics](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_workspace) | resource |
+| [azurerm_monitor_aad_diagnostic_setting.signin_logs](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_aad_diagnostic_setting) | resource |
+| [azurerm_monitor_action_group.security_alerts](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_action_group) | resource |
+| [azurerm_monitor_scheduled_query_rules_alert.breakglass_signin](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_scheduled_query_rules_alert) | resource |
+| [azurerm_resource_group.log_analytics](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
 | [azurerm_role_assignment.owner](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [azuread_domains.initial](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/domains) | data source |
 | [azurerm_client_config.core](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) | data source |
@@ -43,7 +46,13 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_azure_ad_p2"></a> [azure\_ad\_p2](#input\_azure\_ad\_p2) | Set to true if tenant has Azure AD P2-licenses to enable sign-in alerts | `bool` | `false` | no |
+| <a name="input_azure_location"></a> [azure\_location](#input\_azure\_location) | Region in Azure | `string` | `"westeurope"` | no |
+| <a name="input_log_analytics_resource_group_name"></a> [log\_analytics\_resource\_group\_name](#input\_log\_analytics\_resource\_group\_name) | Name of the resource group for the log analytics workspace | `string` | `"RG-AzureAD-Diagnostics"` | no |
+| <a name="input_log_analytics_workspace_name"></a> [log\_analytics\_workspace\_name](#input\_log\_analytics\_workspace\_name) | Name of the log analytics workspace | `string` | `"LA-AzureAD-Diagnostics"` | no |
+| <a name="input_log_analytics_workspace_retention_in_days"></a> [log\_analytics\_workspace\_retention\_in\_days](#input\_log\_analytics\_workspace\_retention\_in\_days) | Workspace retention in days | `number` | `30` | no |
 | <a name="input_password"></a> [password](#input\_password) | Password for the breakglass account | `string` | n/a | yes |
+| <a name="input_security_email_alerts"></a> [security\_email\_alerts](#input\_security\_email\_alerts) | Email address to send security alerts when Emergency access account is used | `string` | n/a | yes |
 | <a name="input_username"></a> [username](#input\_username) | Username for the breakglass account | `string` | `"breakglass"` | no |
 
 ## Outputs

--- a/monitor.tf
+++ b/monitor.tf
@@ -61,7 +61,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert" "breakglass_signin" {
   time_window = 30
   throttling  = 30
   trigger {
-    operator = "GreaterThan"
+    operator = "GreaterThanOrEqual"
     threshold = 1
   }
 }

--- a/monitor.tf
+++ b/monitor.tf
@@ -1,0 +1,67 @@
+resource "azurerm_resource_group" "log_analytics" {
+  count    = var.azure_ad_p2 == true ? 1 : 0
+  name     = var.log_analytics_resource_group_name
+  location = var.azure_location
+}
+
+resource "azurerm_log_analytics_workspace" "azure_ad_diagnostics" {
+  count               = var.azure_ad_p2 == true ? 1 : 0
+  name                = var.log_analytics_workspace_name
+  location            = azurerm_resource_group.log_analytics[0].location
+  resource_group_name = azurerm_resource_group.log_analytics[0].name
+  retention_in_days   = var.log_analytics_workspace_retention_in_days
+}
+
+resource "azurerm_monitor_aad_diagnostic_setting" "signin_logs" {
+  count                      = var.azure_ad_p2 == true ? 1 : 0
+  name                       = "SigninLogs"
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.azure_ad_diagnostics[0].id
+
+  log {
+    category = "SignInLogs"
+    retention_policy {
+    }
+  }
+}
+
+resource "azurerm_monitor_action_group" "security_alerts" {
+  count               = var.azure_ad_p2 == true ? 1 : 0
+  name                = "Security-Alerts"
+  resource_group_name = azurerm_resource_group.log_analytics[0].name
+  short_name          = "secalerts"
+
+  email_receiver {
+    name          = "Security-Mail-Alerts"
+    email_address = var.security_email_alerts
+  }
+}
+
+resource "azurerm_monitor_scheduled_query_rules_alert" "breakglass_signin" {
+  count               = var.azure_ad_p2 == true ? 1 : 0
+  name                = "Breakglass-Signin"
+  description         = "Alert when Breakglass account is used for sign-ins"
+  location = azurerm_resource_group.log_analytics[0].location
+  resource_group_name = azurerm_resource_group.log_analytics[0].name
+
+  data_source_id  = azurerm_log_analytics_workspace.azure_ad_diagnostics[0].id
+
+  action {
+    action_group  = azurerm_monitor_action_group.security_alerts.*.id
+    email_subject = "Sign-in from Emergency access account detected"
+  }
+
+  query = format(<<-QUERY
+        SigninLogs
+        | project UserPrincipalName
+        | where UserPrincipalName == "%s"
+  QUERY
+  , azuread_user.breakglass.user_principal_name)
+  severity    = 1
+  frequency   = 5
+  time_window = 30
+  throttling  = 30
+  trigger {
+    operator = "GreaterThan"
+    threshold = 1
+  }
+}

--- a/monitor.tf
+++ b/monitor.tf
@@ -20,6 +20,8 @@ resource "azurerm_monitor_aad_diagnostic_setting" "signin_logs" {
   log {
     category = "SignInLogs"
     retention_policy {
+        enabled = true
+        days = 30
     }
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,15 @@
+variable "azure_location" {
+  type        = string
+  default     = "westeurope"
+  description = "Region in Azure"
+}
+
+variable "azure_ad_p2" {
+  type        = bool
+  default     = false
+  description = "Set to true if tenant has Azure AD P2-licenses to enable sign-in alerts"
+}
+
 variable "password" {
   type        = string
   sensitive   = true
@@ -8,4 +20,27 @@ variable "username" {
   type        = string
   default     = "breakglass"
   description = "Username for the breakglass account"
+}
+
+variable "log_analytics_resource_group_name" {
+  type        = string
+  default     = "RG-AzureAD-Diagnostics"
+  description = "Name of the resource group for the log analytics workspace"
+}
+
+variable "log_analytics_workspace_name" {
+  type        = string
+  default     = "LA-AzureAD-Diagnostics"
+  description = "Name of the log analytics workspace"
+}
+
+variable "log_analytics_workspace_retention_in_days" {
+  type        = number
+  default     = 30
+  description = "Workspace retention in days"
+}
+
+variable "security_email_alerts" {
+  type    = string
+  description = "Email address to send security alerts when Emergency access account is used"
 }


### PR DESCRIPTION
Deploy Log Analytics workspace, enable streaming of sign-in logs from Azure AD and alert by email when emergency account is used for sign-ins